### PR TITLE
docs: add hint about usage

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -1,4 +1,6 @@
 module "my_snowpipe" {
+  # In your project, replace the below with a reference to this repo (with an optional `?ref=v...` query parameter):
+  # source = "github.com/Snowflake-Labs/terraform-snowflake-snowpipe-aws"
   source = "../../"
 
   database_name = var.database_name

--- a/examples/simple/main.tf
+++ b/examples/simple/main.tf
@@ -1,4 +1,6 @@
 module "my_snowpipe" {
+  # In your project, replace the below with a reference to this repo (with an optional `?ref=v...` query parameter):
+  # source = "github.com/Snowflake-Labs/terraform-snowflake-snowpipe-aws"
   source = "../../"
 
   database_name = var.database_name


### PR DESCRIPTION
This makes it easier to use the example OOTB.

Alternatively I could change the comment to:
```
  source  = "Snowflake-Labs/snowpipe-aws/snowflake"
  version = "X.X.X"
```
however the version would still need to be looked up in the repo or on https://registry.terraform.io/modules/Snowflake-Labs/snowpipe-aws/snowflake/latest 