### PR TITLE
chore: update checkout plugin

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -14,7 +14,7 @@ jobs:
       SNOWFLAKE_USER: dummy_user
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v1
       - name: Terraform Format
@@ -33,7 +33,7 @@ jobs:
       SNOWFLAKE_USER: dummy_user
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v1
       - name: Terraform Format


### PR DESCRIPTION
see https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/