### PR TITLE
fix: pipe needs to be recreated after stage change (prevent `STOPPED_STAGE_ALTERED`)

### DIFF
--- a/snowpipe.tf
+++ b/snowpipe.tf
@@ -42,4 +42,8 @@ resource "snowflake_pipe" "this" {
   depends_on = [
     snowflake_stage.this
   ]
+
+  replace_triggered_by = [
+    snowflake_stage.this
+  ]
 }

--- a/snowpipe.tf
+++ b/snowpipe.tf
@@ -43,7 +43,9 @@ resource "snowflake_pipe" "this" {
     snowflake_stage.this
   ]
 
-  replace_triggered_by = [
-    snowflake_stage.this
-  ]
+  lifecycle {
+    replace_triggered_by = [
+      snowflake_stage.this
+    ]
+  }
 }


### PR DESCRIPTION
The pipe will go into [`STOPPED_STAGE_ALTERED`](https://docs.snowflake.com/en/sql-reference/functions/system_pipe_status) status if the underlying stage is modified. This happens for example when using `create_stage = false` on this module and bringing your own.

See:

![image](https://github.com/user-attachments/assets/975f4551-c711-4965-9011-337597a4787f)

There is no way to put the pipe into `RUNNING` status via a command, the pipe will need to be recreated each time the stage is altered, which is what the changes in this pull request do.

Internal support case reference: https://app.snowflake.com/support/case/00854731